### PR TITLE
Add a fix for the freq_ctr overshoot calculation overflowing with high limits

### DIFF
--- a/haproxy-lua/added-files/src/flt_weir.c
+++ b/haproxy-lua/added-files/src/flt_weir.c
@@ -381,7 +381,7 @@ struct apply_limit_result {
 static struct apply_limit_result apply_bandwidth_limit(struct freq_ctr* counter, uint limit, int requests,
                                                        unsigned int bytes_available) {
     unsigned int quota_bytes_remaining = 0;
-    int overshoot_bytes = 0;
+    unsigned int overshoot_bytes = 0;
     const uint64_t period_ms = 1000; // All our limits are defined per-second, so the counting period is 1000ms
     const uint64_t max_wait_ms =
         2 * period_ms; // We operate on a sliding window of 2 periods, so never wait for longer than that

--- a/haproxy-lua/patches/0003-Convert-freq_ctr_overshoot_period-to-return-a-uint.patch
+++ b/haproxy-lua/patches/0003-Convert-freq_ctr_overshoot_period-to-return-a-uint.patch
@@ -1,0 +1,98 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jacques Heunis <jheunis@bloomberg.net>
+Date: Wed, 25 Jun 2025 13:22:39 +0100
+Subject: [PATCH] Convert freq_ctr_overshoot_period to return a uint
+
+All of the other bandwidth-limiting code stores limits and intermediate (byte) counters as unsigned integers.
+The exception here is freq_ctr_overshoot_period which takes in unsigned values but returns a signed value.
+While this has the benefit of letting the caller know how far away from overshooting they are, this is not currently
+leveraged anywhere in the codebase, and it has the downside of halving the positive range of the result.
+
+As a consequence, if you defined a bandwidth limit in the range (2GB/s, 4GB/s) the bandwidth limiting logic would
+produce spurious slowdowns because the 'current - expected' calculation can underflow the signed integer give
+a large positive value despite observed traffic being nowhere near the limit.
+
+Converting just the return type from signed to unsigned bumps this 2GB/s soft limit on supported limits to 4GB/s,
+but moreover it makes the range of valid values consistent between the input and output of freq_ctr_overshoot_period
+and with the input and output of other freq_ctr functions, thereby reducing the potential for surprise in
+intermediate calculations - now everything supports the full 0 - 2^32 range.
+---
+ include/haproxy/freq_ctr.h |  2 +-
+ src/flt_bwlim.c            |  4 ++--
+ src/freq_ctr.c             | 19 ++++++++++++-------
+ 3 files changed, 15 insertions(+), 10 deletions(-)
+
+diff --git a/include/haproxy/freq_ctr.h b/include/haproxy/freq_ctr.h
+index 6ddcde842..dfb187483 100644
+--- a/include/haproxy/freq_ctr.h
++++ b/include/haproxy/freq_ctr.h
+@@ -31,7 +31,7 @@
+ ullong _freq_ctr_total_from_values(uint period, int pend, uint tick, ullong past, ullong curr);
+ ullong freq_ctr_total(const struct freq_ctr *ctr, uint period, int pend);
+ ullong freq_ctr_total_estimate(const struct freq_ctr *ctr, uint period, int pend);
+-int freq_ctr_overshoot_period(const struct freq_ctr *ctr, uint period, uint freq);
++uint freq_ctr_overshoot_period(const struct freq_ctr *ctr, uint period, uint freq);
+ uint update_freq_ctr_period_slow(struct freq_ctr *ctr, uint period, uint inc);
+ 
+ /* Only usable during single threaded startup phase. */
+diff --git a/src/flt_bwlim.c b/src/flt_bwlim.c
+index 3c75b9bb0..40a876790 100644
+--- a/src/flt_bwlim.c
++++ b/src/flt_bwlim.c
+@@ -79,9 +79,9 @@ static int bwlim_apply_limit(struct filter *filter, struct channel *chn, unsigne
+ 	struct bwlim_state *st = filter->ctx;
+ 	struct freq_ctr *bytes_rate;
+ 	uint64_t remain;
+-	unsigned int period, limit, tokens, users, factor;
++	unsigned int period, limit, tokens, users, factor, overshoot;
+ 	unsigned int wait = 0;
+-	int overshoot, ret = 0;
++	int ret = 0;
+ 
+ 	/* Don't forward anything if there is nothing to forward or the waiting
+ 	 * time is not expired
+diff --git a/src/freq_ctr.c b/src/freq_ctr.c
+index 7f9e346de..571798297 100644
+--- a/src/freq_ctr.c
++++ b/src/freq_ctr.c
+@@ -184,17 +184,17 @@ ullong freq_ctr_total_estimate(const struct freq_ctr *ctr, uint period, int pend
+ 	return _freq_ctr_total_from_values(period, pend, tick, past, curr);
+ }
+ 
+-/* Returns the excess of events (may be negative) over the current period for
+- * target frequency <freq>. It returns 0 if the counter is in the future or if
+- * the counter is empty. The result considers the position of the current time
+- * within the current period.
++/* Returns the excess of events over the current period for target frequency
++ * <freq>. It returns 0 if the counter is in the future or if the counter is
++ * empty. The result considers the position of the current time within the
++ * current period.
+  *
+  * The caller may safely add new events if result is negative or null.
+  */
+-int freq_ctr_overshoot_period(const struct freq_ctr *ctr, uint period, uint freq)
++uint freq_ctr_overshoot_period(const struct freq_ctr *ctr, uint period, uint freq)
+ {
+ 	ullong curr, old_curr;
+-	uint tick, old_tick;
++	uint tick, old_tick, expected_max_count;
+ 	int elapsed;
+ 
+ 	tick = HA_ATOMIC_LOAD(&ctr->curr_tick);
+@@ -245,7 +245,12 @@ int freq_ctr_overshoot_period(const struct freq_ctr *ctr, uint period, uint freq
+ 		return 0;
+ 	}
+ 
+-	return curr - div64_32((uint64_t)elapsed * freq, period);
++	expected_max_count = div64_32((uint64_t)elapsed * freq, period);
++	if (curr < expected_max_count) {
++		/* The counter is below a uniform linear increase across the period, no overshoot */
++		return 0;
++	}
++	return curr - expected_max_count;
+ }
+ 
+ /*
+-- 
+2.43.0
+


### PR DESCRIPTION
Bandwidth limits in haproxy are almost always stored or passed around as uints internally. The one exception to that is freq_ctr_overshoot_period, which calculates how far over the limit a freq_ctr has gone (producing the minimum amount of time that the user should wait before submitting more events). This result is returned currently as a signed integer. This is not inherently problematic, but it's a little strange (all other quantities are unsigned in those calculations, and they're all closely related) and also the conversion to a signed quantity happens implicitly right at the end, after a possible overflow of the unsigned intermediate value. The end result of this for us is that if you set a very high limit when using the freq_ctr-based bandwidth limiting, then in some cases you will be instructed to wait for a long time, causing transfers to stall.

Note that this does not affect us currently because the new bandwidth limiting code has been unhooked for now until we can get the time to properly investigate the stale connection issues and get it back in.

I've also submitted this patch to HAProxy itself so we'll see what they say. If they accept it then much like our earlier bugfixes this patch will go away in a future HAProxy upgrade.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
