### PR TITLE
Remove style and test checks from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,4 @@ much longer to review, or result in it not being reviewed at all.
 - [ ] Existing issues have been referenced (where applicable)
 - [ ] I have verified this change is not present in other open pull requests
 - [ ] Functionality is documented
-- [ ] All code style checks pass
 - [ ] New code contribution is covered by automated tests
-- [ ] All new and existing tests pass


### PR DESCRIPTION
These are/should be validated automatically by the CI actions, it seems unnecessary to complicate the list of manual checks on each PR. Having a shorter list means less overhead and more attention to the other bits that aren't automated.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)