### PR TITLE
Remove broken Security Vulnerability Reporting link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 - [Contributions](#contributions)
 - [License](#license)
 - [Code of Conduct](#code-of-conduct)
-- [Security Vulnerability Reporting](#security-vulnerability-reporting)
 
 ## Rationale
 


### PR DESCRIPTION
We use the org-wide security reporting document instead, which is visible on Github under the 'Security' tab on the README. This seems sufficiently discoverable and will be updated automatically for all repos in the org, so we don't have to manage it separately here.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/bloomberg/weir-qos/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] New code contribution is covered by automated tests
