### PR TITLE
Remove check for 20-character keys in polygen

### DIFF
--- a/polygen/weir/services/metric_service.py
+++ b/polygen/weir/services/metric_service.py
@@ -8,7 +8,6 @@ from weir.models.user_metrics import (
 
 
 class MetricService:
-    AWS_ACCESSKEY_LENGTH = [19, 20]
     ACCESSKEY_PLACEHOLDER = "common"
 
     @staticmethod
@@ -18,9 +17,9 @@ class MetricService:
             raise Exception(f"invalid key {key} retrieved from redis-qos")
 
         def _validate_access_key(usage: UserLevelUsage) -> None:
-            if usage.access_key != MetricService.ACCESSKEY_PLACEHOLDER and (
-                len(usage.access_key) not in MetricService.AWS_ACCESSKEY_LENGTH
-                or not usage.access_key.isalnum()
+            if (
+                usage.access_key != MetricService.ACCESSKEY_PLACEHOLDER
+                and not usage.access_key.isalnum()
             ):
                 raise Exception(
                     f"access_key={usage.access_key} has invalid format for key {usage.key}"


### PR DESCRIPTION
# Description

This was previously used because that is the length of AWS S3 access keys, however we no longer restrict ourselves to supporting only the S3 protocol and this length assumption is not used anywhere else that I am aware of.

Without this change we get lots of errors when sending a key that is shorter or longer, with the change it works just fine without producing any errors for the longer/shorter keys. So removing it is broadening the applicability of the project with no loss of functionality. If desired, we can always add a length check to the S3-specific code in weir-s3.lua, but I'm not convinced that this would add a whole lot of value either, since that would just end up being an invalid key anyway.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/bloomberg/weir-qos/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] New code contribution is covered by automated tests
