### PR TITLE
Update example config to use DEFAULT as the default QoS policy

### DIFF
--- a/examples/dev_cfg/polygen_user_limits.json
+++ b/examples/dev_cfg/polygen_user_limits.json
@@ -1,11 +1,11 @@
 {
     "user_to_qos_id": {
-        "user1key901234567890": "COMMON_QOS",
-        "user2key901234567890": "COMMON_QOS",
-        "common": "COMMON_QOS"
+        "user1key901234567890": "DEFAULT",
+        "user2key901234567890": "DEFAULT",
+        "common": "DEFAULT"
     },
     "qos": {
-        "COMMON_QOS": {
+        "DEFAULT": {
             "user_DELETE": 2,
             "user_GET": 2,
             "user_HEAD": 2,

--- a/polygen/README.md
+++ b/polygen/README.md
@@ -12,11 +12,11 @@ For example:
 ```
 {
     "user_to_qos_id": {
-        "user1key901234567890": "default",
-        "common": "default"
+        "user1key901234567890": "DEFAULT",
+        "common": "DEFAULT"
     },
     "qos": {
-        "default": {
+        "DEFAULT": {
             "user_DELETE": 2,
             "user_GET": 2,
             "user_HEAD": 2,
@@ -30,10 +30,11 @@ For example:
 }
 ```
 
-In the above `user1key901234567890` is the identifier of a user and `default` is the name of a limit tier, with the value of each limit to apply.
+In the above `user1key901234567890` is the identifier of a user and `DEFAULT` is the name of a limit tier, with the value of each limit to apply.
 
 Note that there is another user identifier `common`.
-This is a special value recognised by the system to represent any request for which no identifier can be determined (e.g if the relevant headers were not provided in a request).
+This is a special value used by the S3 implementation to represent any request for which no identifier can be determined (e.g if the relevant headers were not provided in a request).
+The QoS ID `DEFAULT` is also special: across all implementations, any user that does not have a policy explicitly defined (IE does not exist in the `user_to_qos_id` map) will fall back to using the values defined in the `DEFAULT` policy.
 
 # Live reload
 The "dynamic file" with regularly-changing user info can also be live-reloaded so pull in changes without restarting polygen.

--- a/polygen/weir/services/metric_service.py
+++ b/polygen/weir/services/metric_service.py
@@ -8,8 +8,6 @@ from weir.models.user_metrics import (
 
 
 class MetricService:
-    ACCESSKEY_PLACEHOLDER = "common"
-
     @staticmethod
     def create_user_level_metric(key: str, current_epoch: int) -> UserLevelUsage:
         items = key.split("_")
@@ -17,10 +15,7 @@ class MetricService:
             raise Exception(f"invalid key {key} retrieved from redis-qos")
 
         def _validate_access_key(usage: UserLevelUsage) -> None:
-            if (
-                usage.access_key != MetricService.ACCESSKEY_PLACEHOLDER
-                and not usage.access_key.isalnum()
-            ):
+            if not usage.access_key.isalnum():
                 raise Exception(
                     f"access_key={usage.access_key} has invalid format for key {usage.key}"
                 )


### PR DESCRIPTION
# Description

The 'common' user is specific to S3 as its length differs from all valid S3 access keys and tokens.
Any request with no access key provided is assigned the key 'common' by the S3 lua code.

On top of this, we also have logic in polygen to assign limits to all users by falling back
to the values defined by the 'DEFAULT' policy. Here we update the example to use that policy
for the example users as well, so that any undefined users have something set and do not
fall back to the hard-coded defaults.

Without this, anybody who tried to use the default config with their own, non-S3 lua code for haproxy would see errors (resulting from the fallback to hard-coded limits).

While I was at it I also: updated the documentation to call this out correctly, and removed the check for `common` in polygen which is unnecessary and reduces the amount of S3-specific logic in polygen (since I now have a working example I think that's actually the last of it).

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/bloomberg/weir-qos/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] New code contribution is covered by automated tests
