### PR TITLE
Update for Haproxy 3.3.6

### DIFF
--- a/haproxy-lua/activate.sh
+++ b/haproxy-lua/activate.sh
@@ -3,12 +3,12 @@
 set -e
 WEIR_HAPROXY_BASE_COMMIT=v3.3.6
 # Use the major.minor series (for example, 3.3) for the upstream repo name.
-# Expect commit tags in form v<major>.<minor>.<patch> (for example, v3.3.6).
-if [[ "$WEIR_HAPROXY_BASE_COMMIT" =~ ^v([0-9]+\.[0-9]+)\.[0-9]+$ ]]; then
+# Accept commit tags in form v<major>.<minor>.<patch> or <major>.<minor>.<patch>.
+if [[ "$WEIR_HAPROXY_BASE_COMMIT" =~ ^v?([0-9]+\.[0-9]+)\.[0-9]+$ ]]; then
     WEIR_HAPROXY_SERIES=${BASH_REMATCH[1]}
 else
     echo "Invalid WEIR_HAPROXY_BASE_COMMIT: $WEIR_HAPROXY_BASE_COMMIT"
-    echo "Expected format: v<major>.<minor>.<patch> (for example, v3.3.6)"
+    echo "Expected format: [v]<major>.<minor>.<patch> (for example, v3.3.6 or 3.3.6)"
     exit 1
 fi
 SCRIPT_DIR=$(dirname "$0")
@@ -28,16 +28,26 @@ fi
 
 # Store the commit on which our local changes are based, so that we know which commits need to be
 # turned into patches when we later run the `deactivate` script.
-# Ensure release tags are available even if git is configured to skip tags during clone.
-git -C "$HAPROXY_SOURCE_DIR" fetch --tags --force origin
+# Always fetch release tags from upstream source to avoid mirror tag lag.
+WEIR_HAPROXY_TAG_SOURCE_URL=${WEIR_HAPROXY_TAG_SOURCE_URL:-https://git.haproxy.org/git/haproxy-$WEIR_HAPROXY_SERIES.git}
+git -C "$HAPROXY_SOURCE_DIR" fetch --tags --force "$WEIR_HAPROXY_TAG_SOURCE_URL"
 
-if ! git -C "$HAPROXY_SOURCE_DIR" rev-parse --verify --quiet "refs/tags/$WEIR_HAPROXY_BASE_COMMIT" > /dev/null; then
-    echo "Tag $WEIR_HAPROXY_BASE_COMMIT was not found in $HAPROXY_SOURCE_DIR"
+WEIR_HAPROXY_TAG="$WEIR_HAPROXY_BASE_COMMIT"
+if ! git -C "$HAPROXY_SOURCE_DIR" rev-parse --verify --quiet "refs/tags/$WEIR_HAPROXY_TAG" > /dev/null; then
+    if [[ "$WEIR_HAPROXY_BASE_COMMIT" == v* ]]; then
+        WEIR_HAPROXY_TAG=${WEIR_HAPROXY_BASE_COMMIT#v}
+    else
+        WEIR_HAPROXY_TAG=v$WEIR_HAPROXY_BASE_COMMIT
+    fi
+fi
+
+if ! git -C "$HAPROXY_SOURCE_DIR" rev-parse --verify --quiet "refs/tags/$WEIR_HAPROXY_TAG" > /dev/null; then
+    echo "Tag $WEIR_HAPROXY_BASE_COMMIT (or alternate form $WEIR_HAPROXY_TAG) was not found in $HAPROXY_SOURCE_DIR"
     exit 1
 fi
 
-git -C "$HAPROXY_SOURCE_DIR" checkout "$WEIR_HAPROXY_BASE_COMMIT"
-git -C "$HAPROXY_SOURCE_DIR" show-ref -s "refs/tags/$WEIR_HAPROXY_BASE_COMMIT" > "$SCRIPT_DIR"/.haproxy-activated-commit
+git -C "$HAPROXY_SOURCE_DIR" checkout "$WEIR_HAPROXY_TAG"
+git -C "$HAPROXY_SOURCE_DIR" show-ref -s "refs/tags/$WEIR_HAPROXY_TAG" > "$SCRIPT_DIR"/.haproxy-activated-commit
 
 # Enable ** for directory expansion in globs, and allow zero matches to result in an empty list
 shopt -s globstar nullglob

--- a/haproxy-lua/activate.sh
+++ b/haproxy-lua/activate.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/bash
 
 set -e
-
-WEIR_HAPROXY_BASE_COMMIT=v3.3.0
+WEIR_HAPROXY_BASE_VERSION=3.3
+WEIR_HAPROXY_BASE_COMMIT=v3.3.6
+# Use the major.minor series (for example, 3.3) for the upstream repo name.
+WEIR_HAPROXY_SERIES=${WEIR_HAPROXY_BASE_COMMIT#v}
+WEIR_HAPROXY_SERIES=${WEIR_HAPROXY_SERIES%.*}
 SCRIPT_DIR=$(dirname "$0")
 HAPROXY_SOURCE_DIR=$SCRIPT_DIR/haproxy-source
 
@@ -10,7 +13,7 @@ HAPROXY_SOURCE_DIR=$SCRIPT_DIR/haproxy-source
 if [[ -d "$HAPROXY_SOURCE_DIR" ]]; then
     echo "HAProxy directory already exists @ $HAPROXY_SOURCE_DIR, skipping clone step..."
 else
-    git clone "${WEIR_HAPROXY_REPO_URL:-https://github.com/haproxy/haproxy.git}" "$HAPROXY_SOURCE_DIR"
+    git clone "${WEIR_HAPROXY_REPO_URL:-https://git.haproxy.org/git/haproxy-$WEIR_HAPROXY_SERIES.git}" "$HAPROXY_SOURCE_DIR"
 fi
 
 if (! git -C  "$HAPROXY_SOURCE_DIR" diff --quiet) || (! git -C  "$HAPROXY_SOURCE_DIR" diff --staged --quiet); then

--- a/haproxy-lua/activate.sh
+++ b/haproxy-lua/activate.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/bash
 
 set -e
-WEIR_HAPROXY_BASE_VERSION=3.3
 WEIR_HAPROXY_BASE_COMMIT=v3.3.6
 # Use the major.minor series (for example, 3.3) for the upstream repo name.
-WEIR_HAPROXY_SERIES=${WEIR_HAPROXY_BASE_COMMIT#v}
-WEIR_HAPROXY_SERIES=${WEIR_HAPROXY_SERIES%.*}
+# Expect commit tags in form v<major>.<minor>.<patch> (for example, v3.3.6).
+if [[ "$WEIR_HAPROXY_BASE_COMMIT" =~ ^v([0-9]+\.[0-9]+)\.[0-9]+$ ]]; then
+    WEIR_HAPROXY_SERIES=${BASH_REMATCH[1]}
+else
+    echo "Invalid WEIR_HAPROXY_BASE_COMMIT: $WEIR_HAPROXY_BASE_COMMIT"
+    echo "Expected format: v<major>.<minor>.<patch> (for example, v3.3.6)"
+    exit 1
+fi
 SCRIPT_DIR=$(dirname "$0")
 HAPROXY_SOURCE_DIR=$SCRIPT_DIR/haproxy-source
 

--- a/haproxy-lua/activate.sh
+++ b/haproxy-lua/activate.sh
@@ -28,8 +28,16 @@ fi
 
 # Store the commit on which our local changes are based, so that we know which commits need to be
 # turned into patches when we later run the `deactivate` script.
-git -C  "$HAPROXY_SOURCE_DIR" checkout $WEIR_HAPROXY_BASE_COMMIT
-git -C  "$HAPROXY_SOURCE_DIR" show-ref -s $WEIR_HAPROXY_BASE_COMMIT > "$SCRIPT_DIR"/.haproxy-activated-commit
+# Ensure release tags are available even if git is configured to skip tags during clone.
+git -C "$HAPROXY_SOURCE_DIR" fetch --tags --force origin
+
+if ! git -C "$HAPROXY_SOURCE_DIR" rev-parse --verify --quiet "refs/tags/$WEIR_HAPROXY_BASE_COMMIT" > /dev/null; then
+    echo "Tag $WEIR_HAPROXY_BASE_COMMIT was not found in $HAPROXY_SOURCE_DIR"
+    exit 1
+fi
+
+git -C "$HAPROXY_SOURCE_DIR" checkout "$WEIR_HAPROXY_BASE_COMMIT"
+git -C "$HAPROXY_SOURCE_DIR" show-ref -s "refs/tags/$WEIR_HAPROXY_BASE_COMMIT" > "$SCRIPT_DIR"/.haproxy-activated-commit
 
 # Enable ** for directory expansion in globs, and allow zero matches to result in an empty list
 shopt -s globstar nullglob

--- a/haproxy-lua/patches/0001-Initial-commit-of-Weir-QoS.patch
+++ b/haproxy-lua/patches/0001-Initial-commit-of-Weir-QoS.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] Initial commit of Weir QoS
  2 files changed, 31 insertions(+)
 
 diff --git a/Makefile b/Makefile
-index 90e791f39..e6be08e58 100644
+index 0997126a0..e1a556efc 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -1003,6 +1003,7 @@ OBJS += src/mux_h2.o src/mux_h1.o src/mux_fcgi.o src/log.o		\
@@ -21,10 +21,10 @@ index 90e791f39..e6be08e58 100644
  ifneq ($(TRACE),)
    OBJS += src/calltrace.o
 diff --git a/src/hlua.c b/src/hlua.c
-index ec2a8ee7b..2332e29c3 100644
+index 21af7199b..bfbd08426 100644
 --- a/src/hlua.c
 +++ b/src/hlua.c
-@@ -14010,6 +14010,35 @@ static void *hlua_alloc(void *ud, void *ptr, size_t osize, size_t nsize)
+@@ -14043,6 +14043,35 @@ static void *hlua_alloc(void *ud, void *ptr, size_t osize, size_t nsize)
  	return ptr;
  }
  
@@ -60,7 +60,7 @@ index ec2a8ee7b..2332e29c3 100644
  /* This function can fail with an abort() due to a Lua critical error.
   * We are in the initialisation process of HAProxy, this abort() is
   * tolerated.
-@@ -14132,6 +14161,7 @@ lua_State *hlua_init_state(int thread_num)
+@@ -14169,6 +14198,7 @@ lua_State *hlua_init_state(int thread_num)
  	hlua_class_function(L, "Alert", hlua_log_alert);
  	hlua_class_function(L, "done", hlua_done);
  	hlua_class_function(L, "use_native_mailers_config", hlua_use_native_mailers_config);
@@ -69,5 +69,5 @@ index ec2a8ee7b..2332e29c3 100644
  
  	lua_setglobal(L, "core");
 -- 
-2.43.0
+2.44.4
 

--- a/haproxy-lua/patches/0002-Add-old-rate-limit-system-specific-hlua-and-Makefile.patch
+++ b/haproxy-lua/patches/0002-Add-old-rate-limit-system-specific-hlua-and-Makefile.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] Add old-rate-limit-system-specific hlua and Makefile changes
  2 files changed, 101 insertions(+), 1 deletion(-)
 
 diff --git a/Makefile b/Makefile
-index e6be08e58..1e86ba270 100644
+index e1a556efc..900c11441 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -1003,7 +1003,7 @@ OBJS += src/mux_h2.o src/mux_h1.o src/mux_fcgi.o src/log.o		\
@@ -22,7 +22,7 @@ index e6be08e58..1e86ba270 100644
  ifneq ($(TRACE),)
    OBJS += src/calltrace.o
 diff --git a/src/hlua.c b/src/hlua.c
-index 2332e29c3..f47693239 100644
+index bfbd08426..d07acf428 100644
 --- a/src/hlua.c
 +++ b/src/hlua.c
 @@ -69,6 +69,7 @@
@@ -33,7 +33,7 @@ index 2332e29c3..f47693239 100644
  
  /* Global LUA flags */
  
-@@ -14039,6 +14040,100 @@ __LJMP static int hlua_ingest_weir_limit_share_update(lua_State *L)
+@@ -14072,6 +14073,100 @@ __LJMP static int hlua_ingest_weir_limit_share_update(lua_State *L)
  	return 1;
  }
  
@@ -134,7 +134,7 @@ index 2332e29c3..f47693239 100644
  /* This function can fail with an abort() due to a Lua critical error.
   * We are in the initialisation process of HAProxy, this abort() is
   * tolerated.
-@@ -14162,6 +14257,9 @@ lua_State *hlua_init_state(int thread_num)
+@@ -14199,6 +14294,9 @@ lua_State *hlua_init_state(int thread_num)
  	hlua_class_function(L, "done", hlua_done);
  	hlua_class_function(L, "use_native_mailers_config", hlua_use_native_mailers_config);
  	hlua_class_function(L, "ingest_weir_limit_share_update", hlua_ingest_weir_limit_share_update);
@@ -144,7 +144,7 @@ index 2332e29c3..f47693239 100644
  	hlua_fcn_reg_core_fcn(L);
  
  	lua_setglobal(L, "core");
-@@ -14410,6 +14508,7 @@ lua_State *hlua_init_state(int thread_num)
+@@ -14447,6 +14545,7 @@ lua_State *hlua_init_state(int thread_num)
  	hlua_class_function(L, "req_set_path",   hlua_http_req_set_path);
  	hlua_class_function(L, "req_set_query",  hlua_http_req_set_query);
  	hlua_class_function(L, "req_set_uri",    hlua_http_req_set_uri);
@@ -152,7 +152,7 @@ index 2332e29c3..f47693239 100644
  
  	hlua_class_function(L, "res_get_headers",hlua_http_res_get_headers);
  	hlua_class_function(L, "res_del_header", hlua_http_res_del_hdr);
-@@ -14419,6 +14518,7 @@ lua_State *hlua_init_state(int thread_num)
+@@ -14456,6 +14555,7 @@ lua_State *hlua_init_state(int thread_num)
  	hlua_class_function(L, "res_set_header", hlua_http_res_set_hdr);
  	hlua_class_function(L, "res_set_status", hlua_http_res_set_status);
  
@@ -161,5 +161,5 @@ index 2332e29c3..f47693239 100644
  
  	/* Register previous table in the registry with reference and named entry. */
 -- 
-2.43.0
+2.44.4
 


### PR DESCRIPTION
# Description

- Updated activate.sh for 3.3.6 upgrade and changed the Haproxy repo source from mirror repo to the source repo https://git.haproxy.org as the 3.3.6 tag is not replicated to the mirror site yet.


## Type of Change

- [ ] Bugfix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/bloomberg/weir-qos/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] New code contribution is covered by automated tests
