### PR TITLE
Use one thread for active requests and verb scan

### DIFF
--- a/polygen/policy_generator.py
+++ b/polygen/policy_generator.py
@@ -21,7 +21,7 @@ from concurrent import futures
 from dataclasses import dataclass
 from enum import Enum
 from hashlib import sha1
-from typing import Any, Iterable, NamedTuple, cast
+from typing import Any, Iterable, NamedTuple
 
 import redis
 import yaml
@@ -754,61 +754,58 @@ def check_loop(policy_generator: PolicyGenerator, sleep_time_milliseconds: int) 
     def check_loop_epoch() -> None:
         epoch_time = time.time()
         epoch_sec = int(epoch_time)
-
-        def submit_keys_for_type(redis_key_type: str) -> None:
-            cursor = 0
-            keys_to_check: list[str] = []
-            redis_scan_result: tuple[int | str, list[str]] = (0, [])
-            scan_pattern = (
-                f"verb_{epoch_sec}_*"
-                if redis_key_type == REDIS_KEY_TYPE_VERB
-                else "conn_*"
-            )
-
-            while True:
-                try:
-                    scan_result = policy_generator.redis_server.scan(
-                        cursor,
-                        match=scan_pattern,
-                        count=policy_generator.redis_keys_batch,
-                    )
-                    redis_scan_result = cast(tuple[int | str, list[str]], scan_result)
-                    # Redis mandates that SCAN will return 2 elements: the cursor and an array of keys
-                    assert isinstance(redis_scan_result, tuple)
-                    assert len(redis_scan_result) == 2
-                except Exception as e:
-                    policy_generator.logger.warning(
-                        f"Redis SCAN failed with exception: {e}"
-                    )
-                    policy_generator.logger.warning(
-                        f"Redis result for pattern {scan_pattern} at epoch {epoch_sec}: {redis_scan_result}"
-                    )
-                    # We need to find the cause of the underlying problem if this happens.
-                    # We break here since the cursor in redis_scan_result might
-                    # have been messed up here.
-                    break
-
-                current_time = time.time()
-                if int(current_time) != epoch_sec:
-                    policy_generator.logger.debug(
-                        f"Redis scan started at {epoch_time} spilled over the next second"
-                    )
-                    return
-
-                keys_to_check += redis_scan_result[1]
-                cursor = int(redis_scan_result[0])
-                if cursor == 0:
-                    break
-
-            if len(keys_to_check) > 0:
-                policy_generator.submit_violation_check(
-                    keys_to_check,
-                    redis_key_type,
-                    current_time,
+        started_epoch_time = epoch_time
+        cursor = 0
+        scan_pattern = "*"
+        all_verb_keys_to_check = set()
+        all_conn_keys_to_check = set()
+        while True:
+            redis_scan_result: tuple[int, list[str]] | None = None
+            try:
+                redis_scan_result = policy_generator.redis_server.scan(
+                    cursor, match=scan_pattern, count=policy_generator.redis_keys_batch
                 )
+                # Redis mandates that SCAN will return 2 elements: the length of the result and an array of results
+                assert isinstance(redis_scan_result, tuple)
+                assert len(redis_scan_result) == 2
+            except Exception as e:
+                policy_generator.logger.warning(
+                    f"Redis SCAN failed with exception: {e}"
+                )
+                if redis_scan_result is not None:
+                    policy_generator.logger.warning(
+                        f"Redis result for epoch {epoch_sec}: {redis_scan_result}"
+                    )
+                # We need to find the cause of the underlying problem if this happens.
+                # We break here since the cursor in redis_scan_result might
+                # have been messed up here.
+                break
 
-        submit_keys_for_type(REDIS_KEY_TYPE_VERB)
-        submit_keys_for_type(REDIS_KEY_TYPE_CONN)
+            epoch_time = time.time()
+            if int(epoch_time) != epoch_sec:
+                policy_generator.logger.debug(
+                    f"Redis scan started at {started_epoch_time} spilled over the next second"
+                )
+                return
+
+            for key in redis_scan_result[1]:
+                if key.startswith(f"verb_{epoch_sec}_"):
+                    all_verb_keys_to_check.add(key)
+                elif key.startswith("conn_"):
+                    all_conn_keys_to_check.add(key)
+
+            cursor = int(redis_scan_result[0])
+            if cursor == 0:
+                break
+
+        if len(all_verb_keys_to_check) > 0:
+            policy_generator.submit_violation_check(
+                list(all_verb_keys_to_check), REDIS_KEY_TYPE_VERB, epoch_time
+            )
+        if len(all_conn_keys_to_check) > 0:
+            policy_generator.submit_violation_check(
+                list(all_conn_keys_to_check), REDIS_KEY_TYPE_CONN, epoch_time
+            )
 
     while True:
         # check reload_limits
@@ -943,14 +940,14 @@ if __name__ == "__main__":
         logging.exception(f"Policy Generator initialization failed: {e}")
         raise
 
-    verb_conn_loop = threading.Thread(
+    check_thread = threading.Thread(
         target=check_loop,
         args=(
             policy_generator,
             policy_generator.sleep_time_milliseconds,
         ),
     )
-    verb_conn_loop.start()
+    check_thread.start()
 
     demand_thread = threading.Thread(
         target=demand_check_loop,
@@ -962,4 +959,4 @@ if __name__ == "__main__":
     demand_thread.start()
 
     demand_thread.join()
-    verb_conn_loop.join()
+    check_thread.join()

--- a/polygen/policy_generator.py
+++ b/polygen/policy_generator.py
@@ -800,12 +800,12 @@ def check_loop(policy_generator: PolicyGenerator, sleep_time_milliseconds: int) 
                 break
 
         policy_generator.submit_violation_check(
-                list(all_verb_keys_to_check), REDIS_KEY_TYPE_VERB, epoch_time
-            )
+            list(all_verb_keys_to_check), REDIS_KEY_TYPE_VERB, epoch_time
+        )
 
         policy_generator.submit_violation_check(
-                list(all_conn_keys_to_check), REDIS_KEY_TYPE_CONN, epoch_time
-            )
+            list(all_conn_keys_to_check), REDIS_KEY_TYPE_CONN, epoch_time
+        )
 
     while True:
         # check reload_limits

--- a/polygen/policy_generator.py
+++ b/polygen/policy_generator.py
@@ -799,12 +799,11 @@ def check_loop(policy_generator: PolicyGenerator, sleep_time_milliseconds: int) 
             if cursor == 0:
                 break
 
-        if len(all_verb_keys_to_check) > 0:
-            policy_generator.submit_violation_check(
+        policy_generator.submit_violation_check(
                 list(all_verb_keys_to_check), REDIS_KEY_TYPE_VERB, epoch_time
             )
-        if len(all_conn_keys_to_check) > 0:
-            policy_generator.submit_violation_check(
+
+        policy_generator.submit_violation_check(
                 list(all_conn_keys_to_check), REDIS_KEY_TYPE_CONN, epoch_time
             )
 

--- a/polygen/policy_generator.py
+++ b/polygen/policy_generator.py
@@ -742,7 +742,7 @@ class PolicyGenerator:
 
 # we query violates from redis and send back policies to haproxies
 def check_loop(
-    policy_generator: PolicyGenerator, redis_key_type: str, sleep_time_milliseconds: int
+    policy_generator: PolicyGenerator, sleep_time_milliseconds: int
 ) -> None:
     avg_pol_gen_loop_run_time_list: list[float] = []
 
@@ -756,50 +756,59 @@ def check_loop(
     def check_loop_epoch() -> None:
         epoch_time = time.time()
         epoch_sec = int(epoch_time)
-        cursor = 0
-        if redis_key_type == REDIS_KEY_TYPE_VERB:
-            scan_pattern = f"verb_{epoch_sec}_*"
-        elif redis_key_type == REDIS_KEY_TYPE_CONN:
-            scan_pattern = "conn_*"
-        else:
-            raise ValueError(f"Invalid redis key type: {redis_key_type}")
-
-        all_keys_to_check = set()
-        while True:
-            try:
-                redis_scan_result = policy_generator.redis_server.scan(
-                    cursor, match=scan_pattern, count=policy_generator.redis_keys_batch
-                )
-                # Redis mandates that SCAN will return 2 elements: the length of the result and an array of results
-                assert isinstance(redis_scan_result, tuple)
-                assert len(redis_scan_result) == 2
-            except Exception as e:
-                policy_generator.logger.warning(
-                    f"Redis SCAN failed with exception: {e}"
-                )
-                policy_generator.logger.warning(
-                    f"Redis result for epoch {epoch_sec}: {redis_scan_result}"
-                )
-                # We need to find the cause of the underlying problem if this happens.
-                # We break here since the cursor in redis_scan_result might
-                # have been messed up here.
-                break
-
-            epoch_time = time.time()
-            if int(epoch_time) != epoch_sec:
-                policy_generator.logger.debug(
-                    f"Redis scan started at {epoch_time} spilled over the next second"
-                )
-                return
-
-            all_keys_to_check.update(redis_scan_result[1])
-            cursor = int(redis_scan_result[0])
-            if cursor == 0:
-                break
-        if len(all_keys_to_check) > 0:
-            policy_generator.submit_violation_check(
-                list(all_keys_to_check), redis_key_type, epoch_time
+        def submit_keys_for_type(redis_key_type: str) -> None:
+            cursor = 0
+            keys_to_check: list[str] = []
+            redis_scan_result: tuple[int | str, list[str]] = (0, [])
+            scan_pattern = (
+                f"verb_{epoch_sec}_*"
+                if redis_key_type == REDIS_KEY_TYPE_VERB
+                else "conn_*"
             )
+
+            while True:
+                try:
+                    redis_scan_result = policy_generator.redis_server.scan(
+                        cursor,
+                        match=scan_pattern,
+                        count=policy_generator.redis_keys_batch,
+                    )
+                    # Redis mandates that SCAN will return 2 elements: the cursor and an array of keys
+                    assert isinstance(redis_scan_result, tuple)
+                    assert len(redis_scan_result) == 2
+                except Exception as e:
+                    policy_generator.logger.warning(
+                        f"Redis SCAN failed with exception: {e}"
+                    )
+                    policy_generator.logger.warning(
+                        f"Redis result for pattern {scan_pattern} at epoch {epoch_sec}: {redis_scan_result}"
+                    )
+                    # We need to find the cause of the underlying problem if this happens.
+                    # We break here since the cursor in redis_scan_result might
+                    # have been messed up here.
+                    break
+
+                current_time = time.time()
+                if int(current_time) != epoch_sec:
+                    policy_generator.logger.debug(
+                        f"Redis scan started at {epoch_time} spilled over the next second"
+                    )
+                    return
+
+                keys_to_check += redis_scan_result[1]
+                cursor = int(redis_scan_result[0])
+                if cursor == 0:
+                    break
+
+            if len(keys_to_check) > 0:
+                policy_generator.submit_violation_check(
+                    keys_to_check,
+                    redis_key_type,
+                    current_time,
+                )
+
+        submit_keys_for_type(REDIS_KEY_TYPE_VERB)
+        submit_keys_for_type(REDIS_KEY_TYPE_CONN)
 
     while True:
         # check reload_limits
@@ -934,25 +943,14 @@ if __name__ == "__main__":
         logging.exception(f"Policy Generator initialization failed: {e}")
         raise
 
-    verb_thread = threading.Thread(
+    verb_conn_loop = threading.Thread(
         target=check_loop,
         args=(
             policy_generator,
-            REDIS_KEY_TYPE_VERB,
             policy_generator.sleep_time_milliseconds,
         ),
     )
-    verb_thread.start()
-
-    conn_thread = threading.Thread(
-        target=check_loop,
-        args=(
-            policy_generator,
-            REDIS_KEY_TYPE_CONN,
-            policy_generator.sleep_time_milliseconds,
-        ),
-    )
-    conn_thread.start()
+    verb_conn_loop.start()
 
     demand_thread = threading.Thread(
         target=demand_check_loop,
@@ -964,5 +962,4 @@ if __name__ == "__main__":
     demand_thread.start()
 
     demand_thread.join()
-    verb_thread.join()
-    conn_thread.join()
+    verb_conn_loop.join()

--- a/polygen/policy_generator.py
+++ b/polygen/policy_generator.py
@@ -741,9 +741,7 @@ class PolicyGenerator:
 
 
 # we query violates from redis and send back policies to haproxies
-def check_loop(
-    policy_generator: PolicyGenerator, sleep_time_milliseconds: int
-) -> None:
+def check_loop(policy_generator: PolicyGenerator, sleep_time_milliseconds: int) -> None:
     avg_pol_gen_loop_run_time_list: list[float] = []
 
     @avg_time(
@@ -756,6 +754,7 @@ def check_loop(
     def check_loop_epoch() -> None:
         epoch_time = time.time()
         epoch_sec = int(epoch_time)
+
         def submit_keys_for_type(redis_key_type: str) -> None:
             cursor = 0
             keys_to_check: list[str] = []

--- a/polygen/policy_generator.py
+++ b/polygen/policy_generator.py
@@ -769,13 +769,14 @@ def check_loop(policy_generator: PolicyGenerator, sleep_time_milliseconds: int) 
                 assert isinstance(redis_scan_result, tuple)
                 assert len(redis_scan_result) == 2
             except Exception as e:
-                policy_generator.logger.warning(
-                    f"Redis SCAN failed with exception: {e}"
+                scan_result_suffix = (
+                    f"; redis_result={redis_scan_result}"
+                    if redis_scan_result is not None
+                    else ""
                 )
-                if redis_scan_result is not None:
-                    policy_generator.logger.warning(
-                        f"Redis result for epoch {epoch_sec}: {redis_scan_result}"
-                    )
+                policy_generator.logger.warning(
+                    f"Redis SCAN failed for epoch {epoch_sec} with exception: {e}{scan_result_suffix}"
+                )
                 # We need to find the cause of the underlying problem if this happens.
                 # We break here since the cursor in redis_scan_result might
                 # have been messed up here.
@@ -789,7 +790,7 @@ def check_loop(policy_generator: PolicyGenerator, sleep_time_milliseconds: int) 
                 return
 
             for key in redis_scan_result[1]:
-                if key.startswith(f"verb_{epoch_sec}_"):
+                if key.startswith(f"verb_{int(started_epoch_time)}_"):
                     all_verb_keys_to_check.add(key)
                 elif key.startswith("conn_"):
                     all_conn_keys_to_check.add(key)

--- a/polygen/policy_generator.py
+++ b/polygen/policy_generator.py
@@ -21,7 +21,7 @@ from concurrent import futures
 from dataclasses import dataclass
 from enum import Enum
 from hashlib import sha1
-from typing import Any, Iterable, NamedTuple
+from typing import Any, Iterable, NamedTuple, cast
 
 import redis
 import yaml
@@ -767,11 +767,12 @@ def check_loop(policy_generator: PolicyGenerator, sleep_time_milliseconds: int) 
 
             while True:
                 try:
-                    redis_scan_result = policy_generator.redis_server.scan(
+                    scan_result = policy_generator.redis_server.scan(
                         cursor,
                         match=scan_pattern,
                         count=policy_generator.redis_keys_batch,
                     )
+                    redis_scan_result = cast(tuple[int | str, list[str]], scan_result)
                     # Redis mandates that SCAN will return 2 elements: the cursor and an array of keys
                     assert isinstance(redis_scan_result, tuple)
                     assert len(redis_scan_result) == 2

--- a/polygen/tests/test_policy_generator.py
+++ b/polygen/tests/test_policy_generator.py
@@ -3,15 +3,17 @@
 
 import logging
 import unittest
+from types import SimpleNamespace
 from typing import Any as AnyType
 from unittest.mock import ANY as ANY_VALUE
-from unittest.mock import Mock
-from unittest.mock import patch
-from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
 from policy_generator import (
     DEFAULT_VERB_BDW_LIMIT_IF_QOS_IS_NOT_CONFIGURED,
     DEFAULT_VERB_RATE_LIMIT_IF_QOS_IS_NOT_CONFIGURED,
     MB,
+    REDIS_KEY_TYPE_CONN,
+    REDIS_KEY_TYPE_VERB,
     VERB_LIMITING_BANDWIDTH_CATEGORY_PATTERN,
     DemandKey,
     DemandMap,
@@ -20,8 +22,6 @@ from policy_generator import (
     LimitConfig,
     Policies,
     PolicyGenerator,
-    REDIS_KEY_TYPE_CONN,
-    REDIS_KEY_TYPE_VERB,
     check_loop,
 )
 from weir.models.user_metrics import UsageValue, UserLevelVerbUsage

--- a/polygen/tests/test_policy_generator.py
+++ b/polygen/tests/test_policy_generator.py
@@ -581,6 +581,5 @@ class TestPolicyGenerator(unittest.TestCase):
         self.assertEqual(policy_generator.submit_violation_check.call_count, 2)
 
 
-
 if __name__ == "__main__":
     unittest.main()

--- a/polygen/tests/test_policy_generator.py
+++ b/polygen/tests/test_policy_generator.py
@@ -6,7 +6,8 @@ import unittest
 from typing import Any as AnyType
 from unittest.mock import ANY as ANY_VALUE
 from unittest.mock import Mock
-
+from unittest.mock import patch
+from types import SimpleNamespace
 from policy_generator import (
     DEFAULT_VERB_BDW_LIMIT_IF_QOS_IS_NOT_CONFIGURED,
     DEFAULT_VERB_RATE_LIMIT_IF_QOS_IS_NOT_CONFIGURED,
@@ -19,6 +20,9 @@ from policy_generator import (
     LimitConfig,
     Policies,
     PolicyGenerator,
+    REDIS_KEY_TYPE_CONN,
+    REDIS_KEY_TYPE_VERB,
+    check_loop,
 )
 from weir.models.user_metrics import UsageValue, UserLevelVerbUsage
 
@@ -538,6 +542,44 @@ class TestPolicyGenerator(unittest.TestCase):
 
         haproxies["endpoint1"][0].add_message.assert_called_once()  # type: ignore [attr-defined]
         haproxies["endpoint1"][1].add_message.assert_called_once()  # type: ignore [attr-defined]
+
+    def test__check_loop__submits_scanned_keys_to_matching_type(self) -> None:
+        policy_generator = SimpleNamespace(
+            zone="test-zone",
+            logger=logging.getLogger("TestPolicyGenerator"),
+            redis_keys_batch=100,
+            redis_server=Mock(),
+            should_reload_limits=False,
+            reload_limits=Mock(),
+            unknown_users=SimpleNamespace(report=Mock()),
+            submit_violation_check=Mock(),
+        )
+        verb_keys = ["verb_123_GET_key$ep"]
+        conn_keys = ["conn_v2_user_up_instance_key$ep"]
+        policy_generator.redis_server.scan.side_effect = [
+            (0, verb_keys),
+            (0, conn_keys),
+        ]
+
+        with (
+            patch("policy_generator.time.time", return_value=123.0),
+            patch("policy_generator.time.sleep", side_effect=RuntimeError("stop")),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "stop"):
+                check_loop(policy_generator, sleep_time_milliseconds=1)
+
+        policy_generator.submit_violation_check.assert_any_call(
+            verb_keys,
+            REDIS_KEY_TYPE_VERB,
+            123.0,
+        )
+        policy_generator.submit_violation_check.assert_any_call(
+            conn_keys,
+            REDIS_KEY_TYPE_CONN,
+            123.0,
+        )
+        self.assertEqual(policy_generator.submit_violation_check.call_count, 2)
+
 
 
 if __name__ == "__main__":

--- a/polygen/tests/test_policy_generator.py
+++ b/polygen/tests/test_policy_generator.py
@@ -557,10 +557,7 @@ class TestPolicyGenerator(unittest.TestCase):
         )
         verb_keys = ["verb_123_GET_key$ep"]
         conn_keys = ["conn_v2_user_up_instance_key$ep"]
-        policy_generator.redis_server.scan.side_effect = [
-            (0, verb_keys),
-            (0, conn_keys),
-        ]
+        policy_generator.redis_server.scan.return_value = (0, verb_keys + conn_keys)
 
         with (
             patch("policy_generator.time.time", return_value=123.0),

--- a/polygen/tests/test_policy_generator.py
+++ b/polygen/tests/test_policy_generator.py
@@ -4,7 +4,8 @@
 import logging
 import unittest
 from types import SimpleNamespace
-from typing import Any as AnyType, cast
+from typing import Any as AnyType
+from typing import cast
 from unittest.mock import ANY as ANY_VALUE
 from unittest.mock import Mock, patch
 

--- a/polygen/tests/test_policy_generator.py
+++ b/polygen/tests/test_policy_generator.py
@@ -4,7 +4,7 @@
 import logging
 import unittest
 from types import SimpleNamespace
-from typing import Any as AnyType
+from typing import Any as AnyType, cast
 from unittest.mock import ANY as ANY_VALUE
 from unittest.mock import Mock, patch
 
@@ -566,7 +566,10 @@ class TestPolicyGenerator(unittest.TestCase):
             patch("policy_generator.time.sleep", side_effect=RuntimeError("stop")),
         ):
             with self.assertRaisesRegex(RuntimeError, "stop"):
-                check_loop(policy_generator, sleep_time_milliseconds=1)
+                check_loop(
+                    cast(PolicyGenerator, policy_generator),
+                    sleep_time_milliseconds=1,
+                )
 
         policy_generator.submit_violation_check.assert_any_call(
             verb_keys,


### PR DESCRIPTION
# Description
Currently, there 2 separate threads responsible for sending QoS violations to Haproxy: one for active connections and one for verbs.  In addition to unnecessary resource consumption, there's also potential for socket message corruption.  Use one thread for both active requests and verb


## Type of Change

- [ ] Bugfix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/bloomberg/weir-qos/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] New code contribution is covered by automated tests
